### PR TITLE
Fix register

### DIFF
--- a/r2-lcp-swift.xcodeproj/project.pbxproj
+++ b/r2-lcp-swift.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		03254C09206A7E41008C68ED /* R2LCPClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03254C0A206A7E41008C68ED /* R2LCPClient.framework */; };
+		5747983B20B2F115000F2EDA /* RegisterItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5747983A20B2F115000F2EDA /* RegisterItems.swift */; };
+		5747983C20B4461F000F2EDA /* R2LCPClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3314BF31FE42F2300C3B790 /* R2LCPClient.framework */; };
 		F331FBF81F8228F8007F16DF /* LCPDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F331FBF71F8228F8007F16DF /* LCPDatabase.swift */; };
 		F35AF9F91F6AB8C700D3F670 /* LcpSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35AF9F81F6AB8C700D3F670 /* LcpSession.swift */; };
 		F35AF9FF1F6ACD3900D3F670 /* LcpParsingError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F35AF9FE1F6ACD3900D3F670 /* LcpParsingError.swift */; };
@@ -45,6 +46,7 @@
 
 /* Begin PBXFileReference section */
 		03254C0A206A7E41008C68ED /* R2LCPClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2LCPClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5747983A20B2F115000F2EDA /* RegisterItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterItems.swift; sourceTree = "<group>"; };
 		F300FA341F8E1AEB00442332 /* R2Shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2Shared.framework; path = Carthage/Build/iOS/R2Shared.framework; sourceTree = "<group>"; };
 		F3314BF31FE42F2300C3B790 /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = Carthage/Build/iOS/R2LCPClient.framework; sourceTree = "<group>"; };
 		F331FBF71F8228F8007F16DF /* LCPDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPDatabase.swift; sourceTree = "<group>"; };
@@ -85,7 +87,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				03254C09206A7E41008C68ED /* R2LCPClient.framework in Frameworks */,
+				5747983C20B4461F000F2EDA /* R2LCPClient.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,6 +107,7 @@
 			children = (
 				F36F9E251F826C17001D0DB4 /* Licenses.swift */,
 				F36F9E271F8270FC001D0DB4 /* Transactions.swift */,
+				5747983A20B2F115000F2EDA /* RegisterItems.swift */,
 			);
 			name = Tables;
 			sourceTree = "<group>";
@@ -330,7 +333,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		03EF7670206A7D6B00C3C24E /* carthage run script */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			files = (
 			);
 			inputPaths = (
@@ -341,6 +344,7 @@
 				"$(SRCROOT)/Carthage/Build/iOS/SQLite.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftyJSON.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/ZIPFoundation.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/R2LCPClient.framework",
 			);
 			name = "carthage run script";
 			outputPaths = (
@@ -376,6 +380,7 @@
 				F3B2C8AC1F66727C007601E4 /* Link.swift in Sources */,
 				F38FB03E1F66840900F9D602 /* ContentKey.swift in Sources */,
 				F331FBF81F8228F8007F16DF /* LCPDatabase.swift in Sources */,
+				5747983B20B2F115000F2EDA /* RegisterItems.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -502,6 +507,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/r2-lcp-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/r2-lcp-swift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/r2-lcp-swift.xcodeproj/xcshareddata/xcschemes/readium-lcp-swift.xcscheme
+++ b/r2-lcp-swift.xcodeproj/xcshareddata/xcschemes/readium-lcp-swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -56,7 +55,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/readium-lcp-swift/LCPDatabase.swift
+++ b/readium-lcp-swift/LCPDatabase.swift
@@ -21,6 +21,7 @@ final class LCPDatabase {
     /// Tables.
     let licenses: Licenses!
     let transactions: Transactions!
+    let registerItems: RegisterItems!
 
     private init() {
         do {
@@ -32,6 +33,7 @@ final class LCPDatabase {
             connection = try Connection(url.absoluteString)
             licenses = Licenses(connection)
             transactions = Transactions(connection)
+            registerItems = RegisterItems(connection)
         } catch {
             fatalError("Error initializing db.")
         }

--- a/readium-lcp-swift/LcpLicense.swift
+++ b/readium-lcp-swift/LcpLicense.swift
@@ -125,8 +125,7 @@ public class LcpLicense: DrmLicense {
         let database = LCPDatabase.shared
 
         // Check that no existing license with license.id are in the base.
-        guard let existingLicense = try? database.licenses.existingLicense(with: license.id),
-            !existingLicense else
+        guard let existingLicense = try? database.registerItems.existingRegister(for: license.id), !existingLicense else
         {
             return
         }
@@ -166,6 +165,7 @@ public class LcpLicense: DrmLicense {
                 //  5.3/ Store the fact the the device / license has been registered.
                 do {
                     try LCPDatabase.shared.licenses.insert(self.license, with: status.status)
+                    try LCPDatabase.shared.registerItems.insert(self.license, deviceNameString: deviceName, deviceIDString: deviceId)
                     return // SUCCESS
                 } catch {
                     print(error.localizedDescription)
@@ -419,6 +419,7 @@ public class LcpLicense: DrmLicense {
                 } else if let error = error {
                     print(error.localizedDescription)
                 }
+                // Keep this, because another insert (under register process) will not run if the book is already registered.
                 try? LCPDatabase.shared.licenses.insert(self.license, with: status.status)
                 fulfill()
             })

--- a/readium-lcp-swift/RegisterItems.swift
+++ b/readium-lcp-swift/RegisterItems.swift
@@ -1,0 +1,70 @@
+//
+//  RegisterItems.swift
+//  readium-lcp-swift
+//
+//  Created by Senda Li on 2018/5/21.
+//  Copyright © 2018 Readium. All rights reserved.
+//
+
+import Foundation
+import SQLite
+
+class RegisterItems {
+    /// Table.
+    let registerItems = Table("RegisterItems")
+    /// Fields.
+    let licenseID = Expression<String>("licenseID")
+    let updated = Expression<Date?>("updated")
+    
+    let deviceName = Expression<String>("deiviceName")
+    let deviceID = Expression<String>("deviceID")
+    
+    init(_ connection: Connection) {
+        _ = try? connection.run(registerItems.create(temporary: false, ifNotExists: true) { t in
+            
+            t.column(licenseID)
+            t.column(updated)
+            
+            t.column(deviceName)
+            t.column(deviceID)
+        })
+    }
+    
+    /// Check if the table already contains an entry for the given license ID.
+    ///
+    /// - Parameter licenseID: The license ID to check for.
+    /// - Returns: A boolean indicating the result of the search, true if found.
+    /// - Throws: .
+    internal func existingRegister(for licenseID: String) throws -> Bool {
+        let db = LCPDatabase.shared.connection
+        // Check if empty.
+        guard try db.scalar(registerItems.count) > 0 else {
+            return false
+        }
+        let query = registerItems.filter(self.licenseID == licenseID)
+        let count = try db.scalar(query.count)
+        
+        return count > 0
+    }
+    
+    /// Add a registered info to the database.
+    ///
+    /// - Parameters:
+    ///   - license: The license related to register info.
+    ///   - deviceNameString: current device name from system.
+    ///   - deviceIDString: the unique id for device.
+    /// - Throws: .
+    internal func insert(_ license: LicenseDocument, deviceNameString: String, deviceIDString: String) throws {
+        let db = LCPDatabase.shared.connection
+        
+        let insertQuery = registerItems.insert(
+            licenseID <- license.id,
+            updated <- Date(),
+            deviceName <- deviceNameString,
+            deviceID <- deviceIDString
+        )
+        
+        try db.run(insertQuery)
+    }
+    
+}


### PR DESCRIPTION
This PR fixed issue of register request.
fixes https://github.com/readium/r2-testapp-swift/issues/101

What is the reason behind the issue:

There are 2 places using `LCPDatabase.shared.licenses.insert`. 
One of them will run in `updateLicenseDocument` no matter success or failure. 
Another will run after `register` success with response 200.

So, the license has already be inserted into database before `register`. But the condition to trigger `register` is (no such license found with the license id). As the result, `register` will never be triggered with such logic.

It could be simply solved by remove the first insert under `updateLicenseDocument`. But the register will also never been triggered if you don't do clean re-install.
This PR created another sql table to store register information, and use the information to decide whether should it do the register.
There is another special case. The register request failed. Then the second insert (under `register`) of license is not trigger. That might be not good for other process which also using the database.  So I didn't remove the first insert under `updateLicenseDocument`.


