### PR TITLE
Fix/register

### DIFF
--- a/readium-lcp-swift/LCPDatabase.swift
+++ b/readium-lcp-swift/LCPDatabase.swift
@@ -38,3 +38,9 @@ final class LCPDatabase {
     }
 }
 
+extension Connection {
+    public var userVersion: Int32 {
+        get { return Int32(try! scalar("PRAGMA user_version") as! Int64)}
+        set { try! run("PRAGMA user_version = \(newValue)") }
+    }
+}

--- a/readium-lcp-swift/LcpLicense.swift
+++ b/readium-lcp-swift/LcpLicense.swift
@@ -125,9 +125,8 @@ public class LcpLicense: DrmLicense {
         let database = LCPDatabase.shared
 
         // Check that no existing license with license.id are in the base.
-        guard let existingLicense = try? database.licenses.existingLicense(with: license.id),
-            !existingLicense else
-        {
+        guard let registered = try? database.licenses.checkRegister(with: license.id), !registered
+        else {
             return
         }
         // Is the Status document fetched.
@@ -165,7 +164,10 @@ public class LcpLicense: DrmLicense {
             } else if httpResponse.statusCode == 200 {
                 //  5.3/ Store the fact the the device / license has been registered.
                 do {
-                    try LCPDatabase.shared.licenses.insert(self.license, with: status.status)
+                    
+                    //try LCPDatabase.shared.licenses.insert(self.license, with: status.status)
+                    try LCPDatabase.shared.licenses.register(forLicenseWith: self.license.id)
+                    
                     return // SUCCESS
                 } catch {
                     print(error.localizedDescription)

--- a/readium-lcp-swift/Licenses.swift
+++ b/readium-lcp-swift/Licenses.swift
@@ -144,10 +144,3 @@ class Licenses {
     }
     
 }
-
-extension Connection {
-    public var userVersion: Int32 {
-        get { return Int32(try! scalar("PRAGMA user_version") as! Int64)}
-        set { try! run("PRAGMA user_version = \(newValue)") }
-    }
-}


### PR DESCRIPTION
In license table, added a col for register. Then change the condition to trigger register request.

Comment the second `insert`, otherwise it will throw because already inserted.
`try LCPDatabase.shared.licenses.insert(self.license, with: status.status)`

fixes readium/r2-testapp-swift#101