### PR TITLE
Ignore status error for initial download.

### DIFF
--- a/readium-lcp-swift/LcpLicense.swift
+++ b/readium-lcp-swift/LcpLicense.swift
@@ -60,7 +60,7 @@ public class LcpLicense: DrmLicense {
     /// Update the Status Document.
     /// - Parametet initialDownloadAttempt: if serverError then Reject with error for initial download attempt otherwise fulfill with error
     /// - Parameter completion:
-    public func fetchStatusDocument(initialDownloadAttempt: Bool) -> Promise<Error?> {
+    public func fetchStatusDocument(shouldRejectError: Bool) -> Promise<Error?> {
         return Promise<Error?> { fulfill, reject in
             guard let statusLink = license.link(withRel: LicenseDocument.Rel.status) else {
                 reject(LcpError.statusLinkNotFound)
@@ -83,7 +83,7 @@ public class LcpLicense: DrmLicense {
                     } ()
                     
                     if let theServerError = serverError {
-                        if initialDownloadAttempt {
+                        if shouldRejectError {
                             reject(theServerError)
                         } else {
                             fulfill(theServerError)
@@ -417,6 +417,18 @@ public class LcpLicense: DrmLicense {
                 }
                 return false
             })
+        }
+    }
+    
+    
+    public func saveLicenseDocumentWithoutStatus() -> Promise<Void> {
+        return Promise<Void> { fulfill, reject in
+            do {
+                try LCPDatabase.shared.licenses.insert(self.license, with: nil)
+                fulfill(())
+            } catch {
+                reject(error)
+            }
         }
     }
     

--- a/readium-lcp-swift/LcpSession.swift
+++ b/readium-lcp-swift/LcpSession.swift
@@ -33,7 +33,7 @@ public class LcpSession {
     public func resolve(using passphrase: String, pemCrl: String) -> Promise<LcpLicense> {
         return firstly {
             // 4/ Check the license status
-            lcpLicense.fetchStatusDocument(initialDownloadAttempt: false)
+            lcpLicense.fetchStatusDocument(shouldRejectError: false)
             }.then{ error -> Promise<Void> in
                 
                 guard let serverError = error as NSError? else {
@@ -57,9 +57,7 @@ public class LcpSession {
                     NotificationCenter.default.post(notification)
                 }
                 
-                return Promise<Void> { fulfill, reject in
-                    fulfill(())
-                }
+                return self.lcpLicense.saveLicenseDocumentWithoutStatus()
                 
             }.then { _ -> Promise<LcpLicense> in
                 /// 4/ Check the rights.


### PR DESCRIPTION
This PR was requested by laurent as reference, don't need to merge. Also need my changes in testapp.
It simply `fullfill`  the error for status request, and save the LCP into database before use it.