### PR TITLE
Add readable error message for duplicated LCP import

### DIFF
--- a/readium-lcp-swift/LcpError.swift
+++ b/readium-lcp-swift/LcpError.swift
@@ -46,6 +46,7 @@ public enum LcpError: Error {
     
     case invalidRights
     case invalidPassphrase
+    case licenseAlreadyExist
     
 /// For the case (revoked, returned, cancelled, expired), app should notify the user and stop there. The message to the user must be clear about the status of the license: don't display "expired" if the status is "revoked". The date and time corresponding to the new status should be displayed (e.g. "The license expired on 01 January 2018").
     case licenseStatusCancelled(Date?)
@@ -156,6 +157,8 @@ extension LcpError: LocalizedError {
             return "The passphrase entered is not valid."
         case .renewPeriod:
             return "Incorrect renewal period, your publication could not be renewed."
+        case .licenseAlreadyExist:
+            return "The LCP license already exist, this import is ignored"
         }
     }
 }

--- a/readium-lcp-swift/LcpLicense.swift
+++ b/readium-lcp-swift/LcpLicense.swift
@@ -424,8 +424,14 @@ public class LcpLicense: DrmLicense {
     public func saveLicenseDocumentWithoutStatus() -> Promise<Void> {
         return Promise<Void> { fulfill, reject in
             do {
-                try LCPDatabase.shared.licenses.insert(self.license, with: nil)
-                fulfill(())
+                
+                let exist = try LCPDatabase.shared.licenses.existingLicense(with: self.license.id)
+                if exist {
+                    reject(LcpError.licenseAlreadyExist)
+                } else {
+                    try LCPDatabase.shared.licenses.insert(self.license, with: nil)
+                    fulfill(())
+                }
             } catch {
                 reject(error)
             }

--- a/readium-lcp-swift/LcpLicense.swift
+++ b/readium-lcp-swift/LcpLicense.swift
@@ -420,20 +420,27 @@ public class LcpLicense: DrmLicense {
         }
     }
     
-    
-    public func saveLicenseDocumentWithoutStatus() -> Promise<Void> {
+    /// Try to save the license document without status document.
+    /// There is also no update logic for the license, because the license url belongs to status.
+    /// - Parameters:
+    ///   - shouldRejectError: should the function reject anny error emitted .
+    ///
+    public func saveLicenseDocumentWithoutStatus(shouldRejectError: Bool) -> Promise<Void> {
         return Promise<Void> { fulfill, reject in
             do {
-                
                 let exist = try LCPDatabase.shared.licenses.existingLicense(with: self.license.id)
-                if exist {
-                    reject(LcpError.licenseAlreadyExist)
+                if exist { // When the LCP license already exist
+                    if shouldRejectError {
+                        reject(LcpError.licenseAlreadyExist)
+                    }
                 } else {
                     try LCPDatabase.shared.licenses.insert(self.license, with: nil)
-                    fulfill(())
                 }
+                fulfill(())
             } catch {
-                reject(error)
+                if shouldRejectError {
+                    reject(error)
+                } else {fulfill(())}
             }
         }
     }

--- a/readium-lcp-swift/LcpSession.swift
+++ b/readium-lcp-swift/LcpSession.swift
@@ -57,7 +57,7 @@ public class LcpSession {
                     NotificationCenter.default.post(notification)
                 }
                 
-                return self.lcpLicense.saveLicenseDocumentWithoutStatus()
+                return self.lcpLicense.saveLicenseDocumentWithoutStatus(shouldRejectError: false)
                 
             }.then { _ -> Promise<LcpLicense> in
                 /// 4/ Check the rights.


### PR DESCRIPTION
Previously it was a error message thrown by database, this one will be much more understandable.