### PR TITLE
Various networking fixes

### DIFF
--- a/readium-lcp-swift/License/License.swift
+++ b/readium-lcp-swift/License/License.swift
@@ -179,7 +179,7 @@ extension License: LCPLicense {
         }
         
         func callHTML(_ url: URL) throws -> Deferred<Data, Error> {
-            guard let statusURL = try? self.license.url(for: .status) else {
+            guard let statusURL = try? self.license.url(for: .status, preferredType: .lcpStatusDocument) else {
                 throw LCPError.licenseInteractionNotAvailable
             }
             
@@ -226,7 +226,7 @@ extension License: LCPLicense {
     
     func returnPublication(completion: @escaping (LCPError?) -> Void) {
         guard let status = self.documents.status,
-            let url = try? status.url(for: .return, with: device.asQueryParameters) else
+            let url = try? status.url(for: .return, preferredType: .lcpStatusDocument, with: device.asQueryParameters) else
         {
             completion(LCPError.licenseInteractionNotAvailable)
             return

--- a/readium-lcp-swift/License/License.swift
+++ b/readium-lcp-swift/License/License.swift
@@ -165,7 +165,7 @@ extension License: LCPLicense {
             return self.network.fetch(url, method: .put)
                 .tryMap { status, data -> Data in
                     switch status {
-                    case 200:
+                    case 100..<400:
                         break
                     case 400:
                         throw RenewError.renewFailed
@@ -188,7 +188,7 @@ extension License: LCPLicense {
                     // We fetch the Status Document again after the HTML interaction is done, in case it changed the License.
                     self.network.fetch(statusURL)
                         .tryMap { status, data in
-                            guard status == 200 else {
+                            guard 100..<400 ~= status else {
                                 throw LCPError.network(nil)
                             }
                             return data
@@ -235,7 +235,7 @@ extension License: LCPLicense {
         network.fetch(url, method: .put)
             .tryMap { status, data in
                 switch status {
-                case 200:
+                case 100..<400:
                     break
                 case 400:
                     throw ReturnError.returnFailed

--- a/readium-lcp-swift/License/LicenseValidation.swift
+++ b/readium-lcp-swift/License/LicenseValidation.swift
@@ -312,7 +312,7 @@ extension LicenseValidation {
         // Short timeout to avoid blocking the License, since the LSD is optional.
         network.fetch(url, timeout: 5)
             .tryMap { status, data -> Event in
-                guard status == 200 else {
+                guard 100..<400 ~= status else {
                     throw LCPError.network(nil)
                 }
                 
@@ -331,7 +331,7 @@ extension LicenseValidation {
         // Short timeout to avoid blocking the License, since it can be updated next time.
         network.fetch(url, timeout: 5)
             .tryMap { status, data -> Event in
-                guard status == 200 else {
+                guard 100..<400 ~= status else {
                     throw LCPError.network(nil)
                 }
                 return .retrievedLicenseData(data)

--- a/readium-lcp-swift/License/LicenseValidation.swift
+++ b/readium-lcp-swift/License/LicenseValidation.swift
@@ -308,7 +308,7 @@ extension LicenseValidation {
     }
     
     private func fetchStatus(of license: LicenseDocument) throws {
-        let url = try license.url(for: .status)
+        let url = try license.url(for: .status, preferredType: .lcpStatusDocument)
         // Short timeout to avoid blocking the License, since the LSD is optional.
         network.fetch(url, timeout: 5)
             .tryMap { status, data -> Event in
@@ -327,7 +327,7 @@ extension LicenseValidation {
     }
     
     private func fetchLicense(from status: StatusDocument) throws {
-        let url = try status.url(for: .license)
+        let url = try status.url(for: .license, preferredType: .lcpLicenseDocument)
         // Short timeout to avoid blocking the License, since it can be updated next time.
         network.fetch(url, timeout: 5)
             .tryMap { status, data -> Event in

--- a/readium-lcp-swift/License/Model/Components/Links.swift
+++ b/readium-lcp-swift/License/Model/Components/Links.swift
@@ -1,15 +1,11 @@
 //
-//  Links.swift
-//  r2-lcp-swift
-//
-//  Created by Mickaël Menu on 14.02.19.
-//
 //  Copyright 2019 Readium Foundation. All rights reserved.
-//  Use of this source code is governed by a BSD-style license which is detailed
-//  in the LICENSE file present in the project repository where this source code is maintained.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
 //
 
 import Foundation
+import R2Shared
 
 public struct Links {
     
@@ -19,9 +15,32 @@ public struct Links {
         links = try json.map(Link.init)
     }
 
-    /// Returns all the links with the given rel.
+    /// Returns all the links with the given `rel`.
     public subscript(rel: String) -> [Link] {
         return links.filter { $0.rel.contains(rel) }
     }
-    
+
+    /// Returns the first link with the given `rel` and optional `type`.
+    public func firstWithRel(_ rel: String, type: MediaType? = nil) -> Link? {
+        links.first { $0.matches(rel: rel, type: type) }
+    }
+
+    /// Returns all the links with the given `rel` and optional `type`.
+    public func filterWithRel(_ rel: String, type: MediaType? = nil) -> [Link] {
+        links.filter { $0.matches(rel: rel, type: type) }
+    }
+
+    /// Returns the first link with the given `rel` and no media type at all.
+    ///
+    /// This is used to fall back when the preferred type is not found.
+    func firstWithRelAndNoType(_ rel: String) -> Link? {
+        links.first { $0.rel.contains(rel) && $0.type == nil }
+    }
+
+}
+
+private extension Link {
+    func matches(rel: String, type: MediaType?) -> Bool {
+        self.rel.contains(rel) && (type?.matches(self.type) ?? true)
+    }
 }

--- a/readium-lcp-swift/License/Model/LicenseDocument.swift
+++ b/readium-lcp-swift/License/Model/LicenseDocument.swift
@@ -90,19 +90,26 @@ public struct LicenseDocument {
     }
 
     /// Returns the first link containing the given rel.
-    public func link(for rel: Rel) -> Link? {
-        return links[rel.rawValue].first
+    public func link(for rel: Rel, type: MediaType? = nil) -> Link? {
+        links.firstWithRel(rel.rawValue, type: type)
     }
 
     /// Returns all the links containing the given rel.
-    public func links(for rel: Rel) -> [Link] {
-        return links[rel.rawValue]
+    public func links(for rel: Rel, type: MediaType? = nil) -> [Link] {
+        links.filterWithRel(rel.rawValue, type: type)
     }
 
     /// Gets and expands the URL for the given rel, if it exits.
+    ///
+    /// If a `preferredType` is given, the first link with both the `rel` and given type will be returned. If none
+    /// are found, the first link with the `rel` and an empty `type` will be returned.
+    ///
     /// - Throws: `LCPError.invalidLink` if the URL can't be built.
-    func url(for rel: Rel, with parameters: [String: LosslessStringConvertible] = [:]) throws -> URL {
-        guard let url = link(for: rel)?.url(with: parameters) else {
+    func url(for rel: Rel, preferredType: MediaType? = nil, with parameters: [String: LosslessStringConvertible] = [:]) throws -> URL {
+        let link = self.link(for: rel, type: preferredType)
+            ?? links.firstWithRelAndNoType(rel.rawValue)
+
+        guard let url = link?.url(with: parameters) else {
             throw ParsingError.url(rel: rel.rawValue)
         }
         

--- a/readium-lcp-swift/Services/CRLService.swift
+++ b/readium-lcp-swift/Services/CRLService.swift
@@ -54,7 +54,7 @@ final class CRLService {
         
         return network.fetch(url, timeout: timeout)
             .tryMap { status, data in
-                guard status == 200 else {
+                guard 100..<400 ~= status else {
                     throw LCPError.crlFetching
                 }
                 return "-----BEGIN X509 CRL-----\(data.base64EncodedString())-----END X509 CRL-----";

--- a/readium-lcp-swift/Services/DeviceService.swift
+++ b/readium-lcp-swift/Services/DeviceService.swift
@@ -62,7 +62,7 @@ final class DeviceService {
             
             return self.network.fetch(url, method: .post)
                 .tryMap { status, data in
-                    guard status == 200 else {
+                    guard 100..<400 ~= status else {
                         return nil
                     }
                     


### PR DESCRIPTION
* Fix getting the license or status links if there are several listed with different media types
    * Use case: an LSD listing also an ACSM license in the `links`.
* Fix considering HTTP redirect statuses (< 400) as errors