### PR TITLE
Revamp the Renew Loan API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+* The Renew Loan API got revamped to better support renewal through a web page.
+    * You will need to implement `LCPRenewDelegate` to coordinate the UX interaction.
+    * Readium ships with a default implementation `LCPDefaultRenewDelegate` to handle web page renewal with `SFSafariViewController`.
 * CocoaPods is not supported anymore.
 
 

--- a/r2-lcp-swift.xcodeproj/project.pbxproj
+++ b/r2-lcp-swift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3ED94D142DA304C6D4E4DB81 /* LCPRenewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED946FE6F293298E0DF8C37 /* LCPRenewDelegate.swift */; };
 		CA26EF7C2280331E0011653E /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26EF7B2280331E0011653E /* Connection.swift */; };
 		CA2AE328221C3CFB008BD18F /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2AE327221C3CFB008BD18F /* Deprecated.swift */; };
 		CA2B6B5224C07880007AF537 /* LCPContentProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2B6B5124C07880007AF537 /* LCPContentProtection.swift */; };
@@ -89,6 +90,7 @@
 
 /* Begin PBXFileReference section */
 		03A5DB9F23B78AD500D5FCBD /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = Carthage/Build/iOS/R2LCPClient.framework; sourceTree = "<group>"; };
+		3ED946FE6F293298E0DF8C37 /* LCPRenewDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPRenewDelegate.swift; sourceTree = "<group>"; };
 		CA26EF7B2280331E0011653E /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
 		CA2AE327221C3CFB008BD18F /* Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecated.swift; sourceTree = "<group>"; };
 		CA2B6B5124C07880007AF537 /* LCPContentProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPContentProtection.swift; sourceTree = "<group>"; };
@@ -380,6 +382,7 @@
 				F3B2C8A51F66727C007601E4 /* LCPError.swift */,
 				CA6CF1A625286FC20025BBB2 /* LCPAcquisition.swift */,
 				CA6CF1B22528984F0025BBB2 /* LCPLicense.swift */,
+				3ED946FE6F293298E0DF8C37 /* LCPRenewDelegate.swift */,
 				CA2AE327221C3CFB008BD18F /* Deprecated.swift */,
 				CA6CF1C52528CB380025BBB2 /* Authentications */,
 				CAB13214220DB5930097DFB5 /* License */,
@@ -607,6 +610,7 @@
 				CAB57BC12204811100E4CB12 /* LicensesService.swift in Sources */,
 				CA2B6B5224C07880007AF537 /* LCPContentProtection.swift in Sources */,
 				CAE7FB7C220C4B7700D03587 /* DeviceService.swift in Sources */,
+				3ED94D142DA304C6D4E4DB81 /* LCPRenewDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/readium-lcp-swift/LCPLicense.swift
+++ b/readium-lcp-swift/LCPLicense.swift
@@ -32,11 +32,12 @@ public protocol LCPLicense: UserRights {
     /// The maximum potential date to renew to.
     /// If nil, then the renew date might not be customizable.
     var maxRenewDate: Date? { get }
-    
-    /// Renews the loan up to a certain date (if possible).
+
+    /// Renews the loan by starting a renew LSD interaction.
     ///
-    /// - Parameter presenting: Used when the renew requires to present an HTML page to the user. The caller is responsible for presenting the URL (for example with SFSafariViewController) and then calling the `dismissed` callback once the website is closed by the user.
-    func renewLoan(to end: Date?, present: @escaping URLPresenter, completion: @escaping (LCPError?) -> Void)
+    /// - Parameter prefersWebPage: Indicates whether the loan should be renewed through a web page if available,
+    ///   instead of programmatically.
+    func renewLoan(with delegate: LCPRenewDelegate, prefersWebPage: Bool, completion: @escaping (CancellableResult<Void, LCPError>) -> Void)
 
     /// Can the user return the loaned publication?
     var canReturnPublication: Bool { get }
@@ -44,4 +45,12 @@ public protocol LCPLicense: UserRights {
     /// Returns the publication to its provider.
     func returnPublication(completion: @escaping (LCPError?) -> Void)
     
+}
+
+extension LCPLicense {
+
+    public func renewLoan(with delegate: LCPRenewDelegate, completion: @escaping (CancellableResult<Void, LCPError>) -> Void) {
+        renewLoan(with: delegate, prefersWebPage: false, completion: completion)
+    }
+
 }

--- a/readium-lcp-swift/LCPRenewDelegate.swift
+++ b/readium-lcp-swift/LCPRenewDelegate.swift
@@ -1,0 +1,77 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import SafariServices
+import UIKit
+import R2Shared
+
+/// UX delegate for the loan renew LSD interaction.
+public protocol LCPRenewDelegate {
+
+    /// Called when the renew interaction allows to customize the end date programmatically.
+    ///
+    /// You can prompt the user for the number of days to renew, for example.
+    /// The returned date should not exceed `maximumDate`.
+    func preferredEndDate(maximum: Date?, completion: @escaping (CancellableResult<Date?, Error>) -> Void)
+
+    /// Called when the renew interaction uses an HTML web page.
+    ///
+    /// You should present the URL in a `SFSafariViewController` and call the `completion` callback when the browser
+    /// is dismissed by the user.
+    func presentWebPage(url: URL, completion: @escaping (CancellableResult<Void, Error>) -> Void)
+
+}
+
+/// Default `LCPRenewDelegate` implementation using standard views.
+///
+/// No date picker is presented for selecting a preferred end date. If you want to support one, you can subclass or
+/// decorate `LCPRenewDelegate`.
+public class LCPDefaultRenewDelegate: NSObject, LCPRenewDelegate {
+
+    private let presentingViewController: UIViewController
+    private let modalPresentationStyle: UIModalPresentationStyle
+
+    public init(presentingViewController: UIViewController, modalPresentationStyle: UIModalPresentationStyle = .formSheet) {
+        self.presentingViewController = presentingViewController
+        self.modalPresentationStyle = modalPresentationStyle
+    }
+
+    public func preferredEndDate(maximum: Date?, completion: @escaping (CancellableResult<Date?, Error>) -> ()) {
+        completion(.success(nil))
+    }
+
+    public func presentWebPage(url: URL, completion: @escaping (CancellableResult<(), Error>) -> ()) {
+        let safariVC = SFSafariViewController(url: url)
+        safariVC.modalPresentationStyle = self.modalPresentationStyle
+        safariVC.presentationController?.delegate = self
+        safariVC.delegate = self
+
+        webPageCallback = completion
+        presentingViewController.present(safariVC, animated: true)
+    }
+
+    private var webPageCallback: ((CancellableResult<(), Error>) -> Void)? = nil
+
+}
+
+extension LCPDefaultRenewDelegate: UIAdaptivePresentationControllerDelegate {
+
+    public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        webPageCallback?(.success(()))
+        webPageCallback = nil
+    }
+
+}
+
+extension LCPDefaultRenewDelegate: SFSafariViewControllerDelegate {
+
+    public func safariViewControllerDidFinish(_ controller: SFSafariViewController) {
+        webPageCallback?(.success(()))
+        webPageCallback = nil
+    }
+
+}

--- a/readium-lcp-swift/License/License.swift
+++ b/readium-lcp-swift/License/License.swift
@@ -158,11 +158,94 @@ extension License: LCPLicense {
     var maxRenewDate: Date? {
         return status?.potentialRights?.end
     }
-    
-    func renewLoan(to end: Date?, present: @escaping URLPresenter, completion: @escaping (LCPError?) -> Void) {
 
-        func callPUT(_ url: URL) -> Deferred<Data, Error> {
-            return self.network.fetch(url, method: .put)
+    func renewLoan(with delegate: LCPRenewDelegate, prefersWebPage: Bool, completion: @escaping (CancellableResult<(), LCPError>) -> ()) {
+
+        func renew() -> Deferred<Data, Error> {
+            deferredCatching {
+                guard let link = findRenewLink() else {
+                    throw LCPError.licenseInteractionNotAvailable
+                }
+
+                if link.mediaType.isHTML {
+                    return try renewWithWebPage(link)
+                } else {
+                    return renewProgrammatically(link)
+                }
+            }
+        }
+
+        // Finds the renew link according to `prefersWebPage`.
+        func findRenewLink() -> Link? {
+            guard let status = self.documents.status else {
+                return nil
+            }
+
+            var types = [MediaType.html, MediaType.xhtml]
+            if (prefersWebPage) {
+                types.append(.lcpStatusDocument)
+            } else {
+                types.insert(.lcpStatusDocument, at: 0)
+            }
+
+            for type in types {
+                if let link = status.link(for: .renew, type: type) {
+                    return link
+                }
+            }
+
+            // Fallback on the first renew link with no media type set and assume it's a PUT action.
+            return status.linkWithNoType(for: .renew)
+        }
+
+        // Renew the loan by presenting a web page to the user.
+        func renewWithWebPage(_ link: Link) throws -> Deferred<Data, Error> {
+            guard
+                let statusURL = try? self.license.url(for: .status, preferredType: .lcpStatusDocument),
+                let url = link.url
+            else {
+                throw LCPError.licenseInteractionNotAvailable
+            }
+
+            return delegate.presentWebPage(url: url)
+                .flatMap {
+                    // We fetch the Status Document again after the HTML interaction is done, in case it changed the
+                    // License.
+                    self.network.fetch(statusURL)
+                        .tryMap { status, data in
+                            guard 100..<400 ~= status else {
+                                throw LCPError.network(nil)
+                            }
+                            return data
+                        }
+                }
+        }
+
+        // Programmatically renew the loan with a PUT request.
+        func renewProgrammatically(_ link: Link) -> Deferred<Data, Error> {
+
+            // Asks the delegate for a renew date if there's an `end` parameter.
+            func preferredEndDate() -> Deferred<Date?, Error> {
+                (link.templateParameters.contains("end"))
+                    ? delegate.preferredEndDate(maximum: maxRenewDate)
+                    : Deferred.success(nil)
+            }
+
+            func makeRenewURL(from endDate: Date?) throws -> URL {
+                var params = device.asQueryParameters
+                if let end = endDate {
+                    params["end"] = end.iso8601
+                }
+
+                guard let url = link.url(with: params) else {
+                    throw LCPError.licenseInteractionNotAvailable
+                }
+                return url
+            }
+
+            return preferredEndDate()
+                .tryMap(makeRenewURL(from:))
+                .flatMap { self.network.fetch($0, method: .put) }
                 .tryMap { status, data -> Data in
                     switch status {
                     case 100..<400:
@@ -177,47 +260,16 @@ extension License: LCPLicense {
                     return data
                 }
         }
-        
-        func callHTML(_ url: URL) throws -> Deferred<Data, Error> {
-            guard let statusURL = try? self.license.url(for: .status, preferredType: .lcpStatusDocument) else {
-                throw LCPError.licenseInteractionNotAvailable
-            }
-            
-            return deferred { success, _, _ in present(url, { success(()) }) }
-                .flatMap { _ in
-                    // We fetch the Status Document again after the HTML interaction is done, in case it changed the License.
-                    self.network.fetch(statusURL)
-                        .tryMap { status, data in
-                            guard 100..<400 ~= status else {
-                                throw LCPError.network(nil)
-                            }
-                            return data
-                        }
-                }
-        }
 
-        deferredCatching {
-            var params = self.device.asQueryParameters
-            if let end = end {
-                params["end"] = end.iso8601
+        renew()
+            .flatMap(validateStatusDocument)
+            .mapError(LCPError.wrap)
+            .resolve { result in
+                // Trick to make sure the delegate is not deallocated before the end of the renew process.
+                _ = type(of: delegate)
+
+                completion(result)
             }
-            
-            guard let status = self.documents.status,
-                let link = status.link(for: .renew),
-                let url = link.url(with: params) else
-            {
-                throw LCPError.licenseInteractionNotAvailable
-            }
-            
-            if link.mediaType.isHTML {
-                return try callHTML(url)
-            } else {
-                return callPUT(url)
-            }
-        }
-        .flatMap(self.validateStatusDocument)
-        .mapError(LCPError.wrap)
-        .resolveWithError(completion)
     }
     
     var canReturnPublication: Bool {
@@ -255,6 +307,18 @@ extension License: LCPLicense {
     fileprivate func validateStatusDocument(data: Data) -> Deferred<Void, Error> {
         return validation.validate(.status(data))
             .map { _ in () }  // We don't want to forward the Validated Documents
+    }
+
+}
+
+extension LCPRenewDelegate {
+
+    public func preferredEndDate(maximum: Date?) -> Deferred<Date?, Error> {
+        Deferred { preferredEndDate(maximum: maximum, completion: $0) }
+    }
+
+    public func presentWebPage(url: URL) -> Deferred<Void, Error> {
+        Deferred { presentWebPage(url: url, completion: $0) }
     }
 
 }

--- a/readium-lcp-swift/License/Model/Components/Link.swift
+++ b/readium-lcp-swift/License/Model/Components/Link.swift
@@ -75,4 +75,12 @@ public struct Link {
         type.flatMap { MediaType.of(mediaType: $0) } ?? .binary
     }
 
+    /// List of URI template parameter keys, if the `Link` is templated.
+    var templateParameters: Set<String> {
+        guard templated else {
+            return []
+        }
+        return URITemplate(href).parameters
+    }
+
 }

--- a/readium-lcp-swift/License/Model/StatusDocument.swift
+++ b/readium-lcp-swift/License/Model/StatusDocument.swift
@@ -100,6 +100,10 @@ public struct StatusDocument {
         links.filterWithRel(rel.rawValue, type: type)
     }
 
+    func linkWithNoType(for rel: Rel) -> Link? {
+        links.firstWithRelAndNoType(rel.rawValue)
+    }
+
     /// Gets and expands the URL for the given rel, if it exits.
     ///
     /// If a `preferredType` is given, the first link with both the `rel` and given type will be returned. If none
@@ -108,7 +112,7 @@ public struct StatusDocument {
     /// - Throws: `LCPError.invalidLink` if the URL can't be built.
     func url(for rel: Rel, preferredType: MediaType? = nil, with parameters: [String: LosslessStringConvertible] = [:]) throws -> URL {
         let link = self.link(for: rel, type: preferredType)
-            ?? links.firstWithRelAndNoType(rel.rawValue)
+            ?? linkWithNoType(for: rel)
 
         guard let url = link?.url(with: parameters) else {
             throw ParsingError.url(rel: rel.rawValue)


### PR DESCRIPTION
* The Renew Loan API got revamped to better support renewal through a web page.
    * You will need to implement `LCPRenewDelegate` to coordinate the UX interaction.
    * Readium ships with a default implementation `LCPDefaultRenewDelegate` to handle web page renewal with `SFSafariViewController`.

See https://github.com/readium/lcp-specs/issues/43 for discussion.