### PR TITLE
Fix really slow opening of large PDF documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to this project will be documented in this file.
     * Readium ships with a default implementation `LCPDefaultRenewDelegate` to handle web page renewal with `SFSafariViewController`.
 * CocoaPods is not supported anymore.
 
+### Fixed
+
+* Fixed really slow opening of large PDF documents.
+
 
 ## [2.0.0-beta.1]
 


### PR DESCRIPTION
Depends on https://github.com/readium/r2-shared-swift/pull/119

The ZIP library we currently use doesn't support random access in deflated entries, [which causes really bad performances when reading a resource by chunks](https://github.com/readium/r2-shared-swift/issues/98) (e.g. reading a large PDF).

A workaround is to cache the resource input stream to reuse it when being requested consecutive ranges. However this isn't enough for LCP, because when requesting a range from an LCP resource, we always read a bit more to align the data with the next AES block. This means that consecutive requests are not properly aligned and the cached input stream is discarded.

To fix this issue, we use a `BufferedResource` around the ZIP resource which will keep in memory a few of the previously read bytes. They can then be used to complete the next requested range from the cached input stream's current offset.