### PR TITLE
Remove dependency to the private LCP library (R2LCPClient.framework)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+* We removed the dependency to the private `R2LCPClient.framework`, which means:
+    * Now `r2-lcp-swift` works as a Carthage dependency, no need to use a submodule anymore.
+    * You do not need to modify `r2-lcp-swift`'s `Cartfile` anymore to add the private `liblcp` dependency.
+    * However, you must provide a facade to `LCPService` (see [README](README.md) for an example implementation).
 * The Renew Loan API got revamped to better support renewal through a web page.
     * You will need to implement `LCPRenewDelegate` to coordinate the UX interaction.
     * Readium ships with a default implementation `LCPDefaultRenewDelegate` to handle web page renewal with `SFSafariViewController`.

--- a/README.md
+++ b/README.md
@@ -4,37 +4,63 @@ Swift wrapper module for LCP support
 
 [Changes and releases are documented in the Changelog](CHANGELOG.md)
 
-## Adding the library to your iOS project
+## Adding the module to your iOS project
 
 > _Note:_ requires Swift 4.2 (and Xcode 10.1).
 
 ### Carthage
 
-[Carthage][] is a simple, decentralized dependency manager for Cocoa. To
-install ReadiumLCP with Carthage:
+[Carthage][] is a simple, decentralized dependency manager for Cocoa. To install `ReadiumLCP` with Carthage:
 
- 1. Make sure Carthage is [installed][Carthage Installation].
+ 1. Make sure Carthage is [installed][Carthage Installation] and up-to-date.
 
- 2. Update your Cartfile to include the following:
+ 2. Update your app's `Cartfile` to include the following:
 
     ```ruby
     github "readium/r2-lcp-swift" "develop"
     ```
 
- 3. Run `carthage update --use-xcframeworks` and
-    [add the appropriate framework][Carthage Usage].
+ 3. Run `carthage update --use-xcframeworks --platform ios` and [add the appropriate frameworks to your app][Carthage Usage].
 
+### Integration in your project
 
-[Carthage]: https://github.com/Carthage/Carthage
-[Carthage Installation]: https://github.com/Carthage/Carthage#installing-carthage
-[Carthage Usage]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
+After adding the `r2-lcp-swift` module to your project and the private `R2LCPClient.framework` provided by [EDRLab](contact@edrlab.org), you can use LCP in your app by creating an instance of `LCPService`.
 
+`LCPService` expects an implementation of `LCPClient`, which acts as a facade to `R2LCPClient.framework`. Copy and paste the following:
 
-### Dependencies in this module
+```swift
+import R2LCPClient
+import ReadiumLCP
+
+let lcpService = LCPService(client: LCPClient())
+
+/// Facade to the private R2LCPClient.framework.
+class LCPClient: ReadiumLCP.LCPClient {
+
+    func createContext(jsonLicense: String, hashedPassphrase: String, pemCrl: String) throws -> LCPClientContext {
+        return try R2LCPClient.createContext(jsonLicense: jsonLicense, hashedPassphrase: hashedPassphrase, pemCrl: pemCrl)
+    }
+
+    func decrypt(data: Data, using context: LCPClientContext) -> Data? {
+        return R2LCPClient.decrypt(data: data, using: context as! DRMContext)
+    }
+
+    func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [String]) -> String? {
+        return R2LCPClient.findOneValidPassphrase(jsonLicense: jsonLicense, hashedPassphrases: hashedPassphrases)
+    }
+
+}
+```
+
+## Dependencies in this module
 
   - [R2Shared](https://github.com/readium/r2-shared-swift) : Custom types shared by several readium-2 Swift modules.
   - [ZIPFoundation](https://github.com/edrlab/ZIPFoundation) : Effortless ZIP Handling in Swift
   - [SQLite.swift](https://github.com/stephencelis/SQLite.swift) : A type-safe, Swift-language layer over SQLite3.
   - [CryptoSwift](https://github.com/krzyzanowskim/CryptoSwift) : CryptoSwift is a growing collection of standard and secure cryptographic algorithms implemented in Swift
 
+
+[Carthage]: https://github.com/Carthage/Carthage
+[Carthage Installation]: https://github.com/Carthage/Carthage#installing-carthage
+[Carthage Usage]: https://github.com/Carthage/Carthage#adding-frameworks-to-an-application
 

--- a/r2-lcp-swift.xcodeproj/project.pbxproj
+++ b/r2-lcp-swift.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3ED94B8AA015ACF0A3976C89 /* LCPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED94B8D1A7FFE4673AE7B29 /* LCPClient.swift */; };
 		3ED94D142DA304C6D4E4DB81 /* LCPRenewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED946FE6F293298E0DF8C37 /* LCPRenewDelegate.swift */; };
+		3ED94EE43308394A43E51641 /* LCPTestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED94983A0E532A984A04672 /* LCPTestClient.swift */; };
 		CA26EF7C2280331E0011653E /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26EF7B2280331E0011653E /* Connection.swift */; };
 		CA2AE328221C3CFB008BD18F /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2AE327221C3CFB008BD18F /* Deprecated.swift */; };
 		CA2B6B5224C07880007AF537 /* LCPContentProtection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2B6B5124C07880007AF537 /* LCPContentProtection.swift */; };
@@ -25,14 +27,12 @@
 		CA4CF4A625CDA7A7005DD935 /* R2Shared.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47D25CDA636005DD935 /* R2Shared.xcframework */; };
 		CA4CF4A725CDA7A7005DD935 /* SQLite.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47825CDA636005DD935 /* SQLite.xcframework */; };
 		CA4CF4A825CDA7A7005DD935 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47925CDA636005DD935 /* ZIPFoundation.xcframework */; };
-		CA4CF4AF25CDA7AC005DD935 /* R2LCPClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF4AC25CDA7A7005DD935 /* R2LCPClient.framework */; };
 		CA4CF4B425CDA7D9005DD935 /* CryptoSwift.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47B25CDA636005DD935 /* CryptoSwift.xcframework */; };
 		CA4CF4B525CDA7D9005DD935 /* Fuzi.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47C25CDA636005DD935 /* Fuzi.xcframework */; };
 		CA4CF4B625CDA7D9005DD935 /* Minizip.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47A25CDA636005DD935 /* Minizip.xcframework */; };
 		CA4CF4B725CDA7D9005DD935 /* R2Shared.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47D25CDA636005DD935 /* R2Shared.xcframework */; };
 		CA4CF4B825CDA7D9005DD935 /* SQLite.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47825CDA636005DD935 /* SQLite.xcframework */; };
 		CA4CF4B925CDA7D9005DD935 /* ZIPFoundation.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF47925CDA636005DD935 /* ZIPFoundation.xcframework */; };
-		CA4CF4BC25CDA7DC005DD935 /* R2LCPClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA4CF4AC25CDA7A7005DD935 /* R2LCPClient.framework */; };
 		CA50B88022B2A777003AFF24 /* R2LCPLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA50B87F22B2A777003AFF24 /* R2LCPLocalizedString.swift */; };
 		CA50B88422B2A822003AFF24 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CA50B88622B2A822003AFF24 /* Localizable.strings */; };
 		CA5A5E0A25208F1B00CF1CCE /* ReadiumLCP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3B2C8871F667222007601E4 /* ReadiumLCP.framework */; platformFilter = ios; };
@@ -89,8 +89,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		03A5DB9F23B78AD500D5FCBD /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = Carthage/Build/iOS/R2LCPClient.framework; sourceTree = "<group>"; };
 		3ED946FE6F293298E0DF8C37 /* LCPRenewDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPRenewDelegate.swift; sourceTree = "<group>"; };
+		3ED94983A0E532A984A04672 /* LCPTestClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPTestClient.swift; sourceTree = "<group>"; };
+		3ED94B8D1A7FFE4673AE7B29 /* LCPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPClient.swift; sourceTree = "<group>"; };
 		CA26EF7B2280331E0011653E /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
 		CA2AE327221C3CFB008BD18F /* Deprecated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deprecated.swift; sourceTree = "<group>"; };
 		CA2B6B5124C07880007AF537 /* LCPContentProtection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPContentProtection.swift; sourceTree = "<group>"; };
@@ -108,8 +109,6 @@
 		CA4CF47B25CDA636005DD935 /* CryptoSwift.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = CryptoSwift.xcframework; path = Carthage/Build/CryptoSwift.xcframework; sourceTree = "<group>"; };
 		CA4CF47C25CDA636005DD935 /* Fuzi.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Fuzi.xcframework; path = Carthage/Build/Fuzi.xcframework; sourceTree = "<group>"; };
 		CA4CF47D25CDA636005DD935 /* R2Shared.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = R2Shared.xcframework; path = Carthage/Build/R2Shared.xcframework; sourceTree = "<group>"; };
-		CA4CF4AC25CDA7A7005DD935 /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = R2LCPClient.framework; sourceTree = "<group>"; };
-		CA4CF4C425CDA8A7005DD935 /* R2LCPClient.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2LCPClient.framework; path = Carthage/Build/iOS/R2LCPClient.framework; sourceTree = "<group>"; };
 		CA50B87F22B2A777003AFF24 /* R2LCPLocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = R2LCPLocalizedString.swift; sourceTree = "<group>"; };
 		CA50B88522B2A822003AFF24 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CA5A5E0525208F1B00CF1CCE /* readium-lcp-swiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "readium-lcp-swiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -124,7 +123,6 @@
 		CA6CF1CC2528CB830025BBB2 /* LCPPassphraseAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPPassphraseAuthentication.swift; sourceTree = "<group>"; };
 		CA6CF1E12528CC8E0025BBB2 /* LCPDialogViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LCPDialogViewController.swift; sourceTree = "<group>"; };
 		CA6CF1EC2528CC9A0025BBB2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LCPDialogViewController.xib; sourceTree = "<group>"; };
-		CA78C9E8244F531A00E559B3 /* R2Shared.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = R2Shared.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA9428FC22B9442300305CDB /* ReadiumLicenseContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumLicenseContainer.swift; sourceTree = "<group>"; };
 		CAB131F5220D81E60097DFB5 /* LicensesRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicensesRepository.swift; sourceTree = "<group>"; };
 		CAB1320A220D9B200097DFB5 /* LCPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LCPService.swift; sourceTree = "<group>"; };
@@ -172,7 +170,6 @@
 				CA4CF4B725CDA7D9005DD935 /* R2Shared.xcframework in Frameworks */,
 				CA4CF4B825CDA7D9005DD935 /* SQLite.xcframework in Frameworks */,
 				CA4CF4B925CDA7D9005DD935 /* ZIPFoundation.xcframework in Frameworks */,
-				CA4CF4BC25CDA7DC005DD935 /* R2LCPClient.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -186,7 +183,6 @@
 				CA4CF4A625CDA7A7005DD935 /* R2Shared.xcframework in Frameworks */,
 				CA4CF4A725CDA7A7005DD935 /* SQLite.xcframework in Frameworks */,
 				CA4CF4A825CDA7A7005DD935 /* ZIPFoundation.xcframework in Frameworks */,
-				CA4CF4AF25CDA7AC005DD935 /* R2LCPClient.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -200,15 +196,6 @@
 				CA2B6B5324C07B12007AF537 /* LCPDecryptor.swift */,
 			);
 			path = "Content Protection";
-			sourceTree = "<group>";
-		};
-		CA4CF4AB25CDA7A7005DD935 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				CA4CF4AC25CDA7A7005DD935 /* R2LCPClient.framework */,
-			);
-			name = iOS;
-			path = Carthage/Build/iOS;
 			sourceTree = "<group>";
 		};
 		CA50B87E22B2A768003AFF24 /* Toolkit */ = {
@@ -238,6 +225,7 @@
 				CA5A5E142520908900CF1CCE /* Fixtures */,
 				CA5A5E0925208F1B00CF1CCE /* Info.plist */,
 				CA5A5E19252090C100CF1CCE /* readium-lcp-swiftTests-Bridging-Header.h */,
+				3ED94983A0E532A984A04672 /* LCPTestClient.swift */,
 			);
 			path = "readium-lcp-swiftTests";
 			sourceTree = "<group>";
@@ -358,7 +346,6 @@
 		F3B2C87D1F667222007601E4 = {
 			isa = PBXGroup;
 			children = (
-				CA4CF4C425CDA8A7005DD935 /* R2LCPClient.framework */,
 				F3B2C8891F667222007601E4 /* readium-lcp-swift */,
 				CA5A5E0625208F1B00CF1CCE /* readium-lcp-swiftTests */,
 				F3B2C8881F667222007601E4 /* Products */,
@@ -378,6 +365,7 @@
 		F3B2C8891F667222007601E4 /* readium-lcp-swift */ = {
 			isa = PBXGroup;
 			children = (
+				3ED94B8D1A7FFE4673AE7B29 /* LCPClient.swift */,
 				CAB1320A220D9B200097DFB5 /* LCPService.swift */,
 				F3B2C8A51F66727C007601E4 /* LCPError.swift */,
 				CA6CF1A625286FC20025BBB2 /* LCPAcquisition.swift */,
@@ -400,15 +388,12 @@
 		F3B2C8AD1F6672E1007601E4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				CA4CF4AB25CDA7A7005DD935 /* iOS */,
 				CA4CF47B25CDA636005DD935 /* CryptoSwift.xcframework */,
 				CA4CF47C25CDA636005DD935 /* Fuzi.xcframework */,
 				CA4CF47A25CDA636005DD935 /* Minizip.xcframework */,
 				CA4CF47D25CDA636005DD935 /* R2Shared.xcframework */,
 				CA4CF47825CDA636005DD935 /* SQLite.xcframework */,
 				CA4CF47925CDA636005DD935 /* ZIPFoundation.xcframework */,
-				CA78C9E8244F531A00E559B3 /* R2Shared.framework */,
-				03A5DB9F23B78AD500D5FCBD /* R2LCPClient.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -557,6 +542,7 @@
 			files = (
 				CA5A5E1B252090C100CF1CCE /* LCPDecryptorTests.swift in Sources */,
 				CA5A5E21252091E000CF1CCE /* Fixtures.swift in Sources */,
+				3ED94EE43308394A43E51641 /* LCPTestClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -611,6 +597,7 @@
 				CA2B6B5224C07880007AF537 /* LCPContentProtection.swift in Sources */,
 				CAE7FB7C220C4B7700D03587 /* DeviceService.swift in Sources */,
 				3ED94D142DA304C6D4E4DB81 /* LCPRenewDelegate.swift in Sources */,
+				3ED94B8AA015ACF0A3976C89 /* LCPClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -847,7 +834,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/**",
 				);
 				INFOPLIST_FILE = "readium-lcp-swift/Info.plist";
@@ -857,7 +843,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -885,7 +870,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/**",
 				);
 				INFOPLIST_FILE = "readium-lcp-swift/Info.plist";
@@ -895,7 +879,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/readium-lcp-swift/Deprecated.swift
+++ b/readium-lcp-swift/Deprecated.swift
@@ -26,7 +26,7 @@ public extension LCPService {
 /// LCP service factory.
 @available(*, unavailable, message: "Use `LCPService()` instead", renamed: "LCPService")
 public func R2MakeLCPService() -> LCPService {
-    LCPService()
+    fatalError("Not implemented")
 }
 
 @available(*, unavailable, message: "Remove all the code in `handleLcpPublication` and use `LCPLibraryService.loadPublication` instead, in the latest version of r2-testapp-swift")

--- a/readium-lcp-swift/LCPClient.swift
+++ b/readium-lcp-swift/LCPClient.swift
@@ -1,0 +1,61 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+
+/// Protocol to implement in reading apps to create a facade to the private R2LCPClient.framework (liblcp).
+///
+/// You can copy and paste this implementation in your project:
+///
+///     import R2LCPClient
+///     import ReadiumLCP
+///
+///     /// Facade to the private R2LCPClient.framework.
+///     class LCPClient: ReadiumLCP.LCPClient {
+///
+///         func createContext(jsonLicense: String, hashedPassphrase: String, pemCrl: String) throws -> LCPClientContext {
+///              return try R2LCPClient.createContext(jsonLicense: jsonLicense, hashedPassphrase: hashedPassphrase, pemCrl: pemCrl)
+///          }
+///
+///          func decrypt(data: Data, using context: LCPClientContext) -> Data? {
+///              return R2LCPClient.decrypt(data: data, using: context as! DRMContext)
+///          }
+///
+///          func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [String]) -> String? {
+///              return R2LCPClient.findOneValidPassphrase(jsonLicense: jsonLicense, hashedPassphrases: hashedPassphrases)
+///          }
+///
+///      }
+public protocol LCPClient {
+
+    /// Create a context for a given license/passphrase tuple.
+    func createContext(jsonLicense: String, hashedPassphrase: String, pemCrl: String) throws -> LCPClientContext
+
+    /// Decrypt provided content, given a valid context is provided.
+    func decrypt(data: Data, using context: LCPClientContext) -> Data?
+
+    /// Given an array of possible password hashes, return a valid password hash for the lcpl licence.
+    func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [String]) -> String?
+
+}
+
+public typealias LCPClientContext = Any
+
+/// Copy of the R2LCPClient.LCPClientError enum.
+///
+/// Order is important, because it is used to match the original enum cases.
+public enum LCPClientError: Int, Error {
+    case licenseOutOfDate = 0
+    case certificateRevoked
+    case certificateSignatureInvalid
+    case licenseSignatureDateInvalid
+    case licenseSignatureInvalid
+    case contextInvalid
+    case contentKeyDecryptError
+    case userKeyCheckInvalid
+    case contentDecryptError
+    case unknown
+}

--- a/readium-lcp-swift/LCPError.swift
+++ b/readium-lcp-swift/LCPError.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import R2LCPClient
 
 public enum LCPError: LocalizedError {
     // The operation can't be done right now because another License operation is running.

--- a/readium-lcp-swift/License/LCPError+wrap.swift
+++ b/readium-lcp-swift/License/LCPError+wrap.swift
@@ -10,7 +10,6 @@
 //
 
 import Foundation
-import R2LCPClient
 
 extension LCPError {
     
@@ -27,14 +26,14 @@ extension LCPError {
             return .licenseRenew(error)
         } else if let error = error as? ReturnError {
             return .licenseReturn(error)
-        } else if let error = error as? LCPClientError {
-            return .licenseIntegrity(error)
         } else if let error = error as? ParsingError {
             return .parsing(error)
         }
         
         let nsError = error as NSError
         switch nsError.domain {
+        case "R2LCPClient.LCPClientError":
+            return .licenseIntegrity(LCPClientError(rawValue: nsError.code) ?? .unknown)
         case NSURLErrorDomain:
             return .network(nsError)
         default:

--- a/readium-lcp-swift/License/License.swift
+++ b/readium-lcp-swift/License/License.swift
@@ -11,7 +11,6 @@
 
 import Foundation
 import ZIPFoundation
-import R2LCPClient
 import R2Shared
 
 
@@ -21,13 +20,15 @@ final class License: Loggable {
     private var documents: ValidatedDocuments
 
     // Dependencies
+    private let client: LCPClient
     private let validation: LicenseValidation
     private let licenses: LicensesRepository
     private let device: DeviceService
     private let network: NetworkService
 
-    init(documents: ValidatedDocuments, validation: LicenseValidation, licenses: LicensesRepository, device: DeviceService, network: NetworkService) {
+    init(documents: ValidatedDocuments, client: LCPClient, validation: LicenseValidation, licenses: LicensesRepository, device: DeviceService, network: NetworkService) {
         self.documents = documents
+        self.client = client
         self.validation = validation
         self.licenses = licenses
         self.device = device
@@ -60,7 +61,7 @@ extension License: LCPLicense {
     
     public func decipher(_ data: Data) throws -> Data? {
         let context = try documents.getContext()
-        return decrypt(data: data, using: context)
+        return client.decrypt(data: data, using: context)
     }
     
     var charactersToCopyLeft: Int? {

--- a/readium-lcp-swiftTests/Content Protection/LCPDecryptorTests.swift
+++ b/readium-lcp-swiftTests/Content Protection/LCPDecryptorTests.swift
@@ -17,7 +17,7 @@ class LCPDecryptorTests: XCTestCase {
     var clearData: Data!
 
     override func setUpWithError() throws {
-        service = LCPService()
+        service = LCPService(client: LCPTestClient())
         
         let fetcher = ArchiveFetcher(archive: try DefaultArchiveFactory().open(url: self.fixtures.url(for: "daisy.lcpdf"), password: nil))
         encryptedResource = fetcher.get(Link(

--- a/readium-lcp-swiftTests/LCPTestClient.swift
+++ b/readium-lcp-swiftTests/LCPTestClient.swift
@@ -1,0 +1,25 @@
+//
+//  Copyright 2021 Readium Foundation. All rights reserved.
+//  Use of this source code is governed by the BSD-style license
+//  available in the top-level LICENSE file of the project.
+//
+
+import Foundation
+import ReadiumLCP
+import R2LCPClient
+
+class LCPTestClient: LCPClient {
+
+    func createContext(jsonLicense: String, hashedPassphrase: String, pemCrl: String) throws -> LCPClientContext {
+        return try R2LCPClient.createContext(jsonLicense: jsonLicense, hashedPassphrase: hashedPassphrase, pemCrl: pemCrl)
+    }
+
+    func decrypt(data: Data, using context: LCPClientContext) -> Data? {
+        return R2LCPClient.decrypt(data: data, using: context as! DRMContext)
+    }
+
+    func findOneValidPassphrase(jsonLicense: String, hashedPassphrases: [String]) -> String? {
+        return R2LCPClient.findOneValidPassphrase(jsonLicense: jsonLicense, hashedPassphrases: hashedPassphrases)
+    }
+
+}


### PR DESCRIPTION
Fix #79 

* Removed the dependency to the private `R2LCPClient.framework`, which means:
    * Now `r2-lcp-swift` works as a Carthage dependency, no need to use a submodule anymore.
    * You do not need to modify `r2-lcp-swift`'s `Cartfile` anymore to add the private `liblcp` dependency.
    * However, you must provide a facade to `LCPService` (see [README](https://github.com/readium/r2-lcp-swift/blob/7d538b1c7153e674062b585922ebbc0cb68bee47/README.md) for an example implementation).

Note: In the future it could be possible to use reflection to avoid using a facade, but it needs some changes in `R2LCPClient.framework` so unlikely to be done soon. For example, global functions are not reachable with reflection.